### PR TITLE
チームリーダーが、他のチームメンバーにリーダー権限を渡せる機能を実装すること/Implement a function that allows team leaders to give leader authority to other team members

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -2,9 +2,9 @@ class AssignsController < ApplicationController
   before_action :authenticate_user!
   before_action :email_exist?, only: [:create]
   before_action :user_exist?, only: [:create]
+  before_action :find_team, only: [:create]
 
   def create
-    team = find_team(params[:team_id])
     user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
     if user
       team.invite_member(user)
@@ -40,7 +40,6 @@ class AssignsController < ApplicationController
   end
 
   def email_exist?
-    team = find_team(params[:team_id])
     if team.members.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.email_already_exists')
     end
@@ -51,7 +50,6 @@ class AssignsController < ApplicationController
   end
 
   def user_exist?
-    team = find_team(params[:team_id])
     unless User.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.does_not_exist_email')
     end
@@ -62,7 +60,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
-    team = Team.friendly.find(params[:team_id])
+  def find_team
+    Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -2,9 +2,9 @@ class AssignsController < ApplicationController
   before_action :authenticate_user!
   before_action :email_exist?, only: [:create]
   before_action :user_exist?, only: [:create]
-  before_action :find_team, only: [:create]
 
   def create
+    team = find_team(params[:team_id])
     user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
     if user
       team.invite_member(user)
@@ -40,6 +40,7 @@ class AssignsController < ApplicationController
   end
 
   def email_exist?
+    team = find_team(params[:team_id])
     if team.members.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.email_already_exists')
     end
@@ -50,6 +51,7 @@ class AssignsController < ApplicationController
   end
 
   def user_exist?
+    team = find_team(params[:team_id])
     unless User.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.does_not_exist_email')
     end
@@ -60,7 +62,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team
+  def find_team(_team_id)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -46,7 +46,12 @@ class TeamsController < ApplicationController
   def dashboard
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
   end
-
+  def invest
+     @team = Team.find_by(name: params[:team_id])
+     # @team.owner_id = params[:id]
+     @team.update(owner_id: params[:id])
+     redirect_to @team, notice: I18n.t('views.messages.invest_owner_authority')
+  end
   private
 
   def set_team

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -47,10 +47,12 @@ class TeamsController < ApplicationController
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
   end
   def invest
-     @team = Team.find_by(name: params[:team_id])
-     # @team.owner_id = params[:id]
-     @team.update(owner_id: params[:id])
-     redirect_to @team, notice: I18n.t('views.messages.invest_owner_authority')
+    # チームリーダが変わった時にメールを飛ばす。viewsに新しいmailのフォームを作る。mailersのファイルに送信するメソッドを記述する。
+    @team = Team.find_by(name: params[:team_id])
+    @target = User.find(params[:id])
+    TeamMailer.owner_mail(@target.email, @team.name).deliver
+    @team.update(owner_id: params[:id])
+    redirect_to @team, notice: I18n.t('views.messages.invest_owner_authority')
   end
   private
 

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -1,6 +1,5 @@
 class AssignMailer < ApplicationMailer
   default from: 'from@example.com'
-
   def assign_mail(email, password)
     @email = email
     @password = password

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -1,0 +1,8 @@
+class TeamMailer < ApplicationMailer
+  default from: 'from@example.com'
+  def owner_mail(email, team_name)
+    @email = email
+    @team_name = team_name
+    mail to: email, subject: I18n.t("views.messages.is_invested_team_owner")
+  end
+end

--- a/app/views/assign_mailer/assign_mail.html.erb
+++ b/app/views/assign_mailer/assign_mail.html.erb
@@ -1,4 +1,4 @@
 <h1><%= I18n.t('views.messages.initial_assign') %></h1>
-
 <h4>email: <%= @email %></h4>
 <p><%= I18n.t('views.messages.initial_password') %> <%= @password %></p>
+

--- a/app/views/team_mailer/owner_mail.html.erb
+++ b/app/views/team_mailer/owner_mail.html.erb
@@ -1,0 +1,2 @@
+<h1><%= I18n.t('views.messages.is_invested_team_owner') %></h1>
+<p><%= I18n.t('views.messages.team_name') %> <%= @team_name %></p>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,7 +42,6 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                      <!-- assignだけじゃだめ? -->
                       <% if @team.owner == current_user %>
                         <td><%= link_to I18n.t('views.button.invest'),  invest_team_assign_path(@team, assign.user.id), method: :patch, class: 'btn btn-sm btn-danger' %></td>
                       <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -43,8 +43,9 @@
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
                       <!-- assignだけじゃだめ? -->
-                      <%#  %>
-                      <td><%= link_to I18n.t('views.button.invest'),  invest_team_assign_path(@team, assign.user.id), method: :patch, class: 'btn btn-sm btn-danger' %></td>
+                      <% if @team.owner == current_user %>
+                        <td><%= link_to I18n.t('views.button.invest'),  invest_team_assign_path(@team, assign.user.id), method: :patch, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,6 +42,9 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <!-- assignだけじゃだめ? -->
+                      <%#  %>
+                      <td><%= link_to I18n.t('views.button.invest'),  invest_team_assign_path(@team, assign.user.id), method: :patch, class: 'btn btn-sm btn-danger' %></td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,7 +205,9 @@ ja:
     pm: 午後
   views:
     messages:
-      invest_owner_authority: 'オーナー権限を譲渡しました!'
+      team_name: 'チーム名'
+      is_invested_team_owner: 'チームのリーダーに任命されました'
+      invest_owner_authority: 'リーダー権限を譲渡しました!'
       create_agenda: 'アジェンダ作成に成功しました！'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,6 +205,7 @@ ja:
     pm: 午後
   views:
     messages:
+      invest_owner_authority: 'オーナー権限を譲渡しました!'
       create_agenda: 'アジェンダ作成に成功しました！'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
@@ -254,6 +255,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
     button:
+      invest: '任命'
       submit: '投稿'
       edit: '編集'
       delete: '削除'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -255,7 +255,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
     button:
-      invest: '任命'
+      invest: '権限移動'
       submit: '投稿'
       edit: '編集'
       delete: '削除'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,13 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
-    resources :assigns, only: %w(create destroy)
+    resources :assigns, only: %w(create destroy) do
+      member do
+        patch :invest, to: 'teams#invest'
+      end
+    end
     resources :agendas, shallow: true do
       resources :articles do
         resources :comments

--- a/spec/mailers/previews/team_mailer_preview.rb
+++ b/spec/mailers/previews/team_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/team_mailer
+class TeamMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/team_mailer_spec.rb
+++ b/spec/mailers/team_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TeamMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
現状、Teamのリーダー（オーナー）は、最初にそのチームを作成したUserに固定され、変更できない仕様になっているが、これを変更できる機能を追加してほしい。

以下の要件で作成されることを想定している

> そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現する
> そのボタンを押すと、そのTeamのオーナーが選択したUserに変更される
> アクションはTeamコントローラに任意のものを追加する
> Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ
> 情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）
> その他、アプリケーションの挙動に不審な点やエラーがないこと

その他、質問や確認事項などがあれば別途課題投稿欄のコメントで質問すること

今回テストは不要