### PR TITLE
アジェンダの削除機能を実装すること（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること）/Implement the agenda delete function（ Delete the article associated with the agenda and send a notification email to all members in the team

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,4 @@
  *= require_tree .
  *= require_self
  */
+ .agenda_delete{margin: 0;}

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -19,6 +19,11 @@ class AgendasController < ApplicationController
     else
       render :new
     end
+  end
+  def destroy
+    @agenda.destroy
+
+    redirect_to dashboard_url, notice: I18n.t('views.messages.destroy_agenda')
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -23,8 +23,8 @@ class AgendasController < ApplicationController
   def destroy
     # params[:id]はアジェンダのid。@agenda.team_idでチームのidを取得
     # 全員のemailを取得する。@agendaのteam_idを使って、TeamのアソシエーションメソッドmembersでUserのemailを取得する。
-
-    if @agenda.destroy
+    if current_user.id == @agenda.user_id || current_user == @agenda.team.owner
+      @agenda.destroy
       team_members_email = @agenda.team.members.pluck(:email)
       team_members_email.each do |email|
         AgendaMailer.delete_mail(email, @agenda).deliver

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -2,9 +2,9 @@ class AssignsController < ApplicationController
   before_action :authenticate_user!
   before_action :email_exist?, only: [:create]
   before_action :user_exist?, only: [:create]
-  before_action :find_team, only: [:create, :email_exist?, :user_exist?]
 
   def create
+    team = find_team(params[:team_id])
     user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
     if user
       team.invite_member(user)
@@ -40,6 +40,7 @@ class AssignsController < ApplicationController
   end
 
   def email_exist?
+    team = find_team(params[:team_id])
     if team.members.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.email_already_exists')
     end
@@ -50,6 +51,7 @@ class AssignsController < ApplicationController
   end
 
   def user_exist?
+    team = find_team(params[:team_id])
     unless User.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.does_not_exist_email')
     end
@@ -60,7 +62,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team
+  def find_team(_team_id)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -2,9 +2,9 @@ class AssignsController < ApplicationController
   before_action :authenticate_user!
   before_action :email_exist?, only: [:create]
   before_action :user_exist?, only: [:create]
+  before_action :find_team, only: [:create, :email_exist?, :user_exist?]
 
   def create
-    team = find_team(params[:team_id])
     user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
     if user
       team.invite_member(user)
@@ -40,7 +40,6 @@ class AssignsController < ApplicationController
   end
 
   def email_exist?
-    team = find_team(params[:team_id])
     if team.members.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.email_already_exists')
     end
@@ -51,7 +50,6 @@ class AssignsController < ApplicationController
   end
 
   def user_exist?
-    team = find_team(params[:team_id])
     unless User.exists?(email: params[:email])
       redirect_to team_url(team), notice: I18n.t('views.messages.does_not_exist_email')
     end
@@ -62,7 +60,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
-    team = Team.friendly.find(params[:team_id])
+  def find_team
+    Team.friendly.find(params[:team_id])
   end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,2 @@
+class AgendaMailer < ApplicationMailer
+end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,2 +1,7 @@
 class AgendaMailer < ApplicationMailer
+  def delete_mail(email, agenda)
+    @email = email
+    @agenda_title = agenda.title
+    mail to: @email, subject: I18n.t('views.messages.complete_delete')
+  end
 end

--- a/app/views/agenda_mailer/delete_mail.html.erb
+++ b/app/views/agenda_mailer/delete_mail.html.erb
@@ -1,0 +1,2 @@
+<h1><%= I18n.t('views.messages.agenda_is_delete') %></h1>
+<p> title:<%= @agenda_title %>> </p>

--- a/app/views/assign_mailer/assign_mail.html.erb
+++ b/app/views/assign_mailer/assign_mail.html.erb
@@ -1,4 +1,3 @@
 <h1><%= I18n.t('views.messages.initial_assign') %></h1>
-
 <h4>email: <%= @email %></h4>
 <p><%= I18n.t('views.messages.initial_password') %> <%= @password %></p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -36,6 +36,7 @@
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>
+              <%= link_to I18n.t('views.button.delete'), agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger' %>
             </a>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,9 +34,10 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                <object><%= link_to I18n.t('views.button.delete'), agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger' %></object>
                 <i class="right fa fa-angle-left"></i>
               </p>
-              <%= link_to I18n.t('views.button.delete'), agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger' %>
+
             </a>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,6 +205,9 @@ ja:
     pm: 午後
   views:
     messages:
+      agenda_is_delete: 'アジェンダが削除されました'
+      complete_delete: '削除完了'
+      can_not_destroy_agenda: 'アジェンダを削除できません'
       destroy_agenda: 'アジェンダを削除しました'
       create_agenda: 'アジェンダ作成に成功しました！'
       create_article: '記事作成に成功しました！'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,6 +205,7 @@ ja:
     pm: 午後
   views:
     messages:
+      destroy_agenda: 'アジェンダを削除しました'
       create_agenda: 'アジェンダ作成に成功しました！'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
現状サイドバーに表示される各アジェンダを削除する機能がないので、その機能を追加してほしい。

以下の要件で作成されることを想定している

- [x] AgendasControllerのdestroyアクションを追加し、そこに機能追加する
- [x] Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- [x] Agendaに紐づいているarticleも一緒に削除される
- [x] Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- [x] Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
- [x] 情報処理が完了した後はDashBoardに飛ぶ
- [x] その他、アプリケーションの挙動に不審な点やエラーがないこと

その他、質問や確認事項などがあれば別途課題投稿欄のコメントで質問すること

今回テストは不要